### PR TITLE
Geometry combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supports windows of various sizes as an example for using custom OBJ files
   * `Mesh Combine Similar`:
     * Entities within same group will be combined into single mesh separated by surface material; new mesh if max surfaces is exceeded
     * Increased loading time
-    * Improves runtime and reduces RAM used
+    * Improved runtime and reduced RAM at load and runtime (large scenes possible on mobile devices)
 
 ## Related Ylands Export Project
 [Ylands Export Project](https://github.com/BinarySemaphore/ylands_exporter)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ylands_scene_loader
+# Ylands Scene Loader (Godot Project)
 Example loader for exported Ylands scenes
 
 Project is duplicated for both *C#* and *Native* Godot.
@@ -8,16 +8,14 @@ Supports windows of various sizes as an example for using custom OBJ files
 > Note: more will be added
 
 ## Requirements
-* Godot (version 4.3 native or C#/.NET)
-  * [Windows](https://godotengine.org/download/windows/)
-  * [Linux](https://godotengine.org/download/linux/)
+* Godot (version 4.3 native or C#/.NET): [Windows](https://godotengine.org/download/windows/) or [Linux](https://godotengine.org/download/linux/) (*Android* and *MacOS* also supported)
 
 ## Controls
 * Move: `W`, `A`, `S`, `D`, `Q`, `Z`
 * Turn: `Arrow Keys`
 * Speed Modifier: `Shift` or `Ctrl`
 
-## Change Scene
+## Change Scene and Other Options
 1. Select the `YlandScene` node
 1. In Inspector tab, find `Metadata`
 1. Enter path for another scene JSON file for `Scene File`
@@ -33,6 +31,7 @@ Supports windows of various sizes as an example for using custom OBJ files
     * Entities within same group will be combined into single mesh separated by surface material; new mesh if max surfaces is exceeded
     * Increased loading time
     * Improved runtime and reduced RAM at load and runtime (large scenes possible on mobile devices)
+    * Allows for saving *remote* scene when running, then exporting as `*.gltf` model for import with 3d editors
 
 ## Related Ylands Export Project
-[Ylands Export Project](https://github.com/BinarySemaphore/ylands_exporter)
+[Ylands Export Project](https://github.com/BinarySemaphore/ylands_exporter) in GitHub

--- a/README.md
+++ b/README.md
@@ -24,8 +24,15 @@ Supports windows of various sizes as an example for using custom OBJ files
   > Tip: In Godot you can right click a file in `Filesystem` and `Copy Path`
 
 * Other Options in `YlandScene` node
-  * `Box Draw Unsupported`: Toggle on/off (default: on) to draw boxes using blockdef bounding box dimensions
-  * `Unsupported Transparency`: 0.0 to 1.0 (default 0.5); if `Box Draw Unsupported` on, sets transparency of boxes; 0 being invisible, 1 being opaque
+  * `Box Draw Unsupported`:
+    * Toggle on/off (default: on) to draw boxes using blockdef bounding box dimensions
+  * `Unsupported Transparency`:
+    * if `Box Draw Unsupported` on sets transparency of boxes
+    * 0.0 to 1.0 (default 0.5); 0 being invisible, 1 being opaque
+  * `Mesh Combine Similar`:
+    * Entities within same group will be combined into single mesh separated by surface material; new mesh if max surfaces is exceeded
+    * Increased loading time
+    * Improves runtime and reduces RAM used
 
 ## Related Ylands Export Project
 [Ylands Export Project](https://github.com/BinarySemaphore/ylands_exporter)

--- a/csharp/scenes/loader_scene.tscn
+++ b/csharp/scenes/loader_scene.tscn
@@ -27,7 +27,7 @@ glow_enabled = true
 environment = SubResource("Environment_qbilp")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
-transform = Transform3D(0.694658, 0.546174, -0.468128, 0, 0.650774, 0.759271, 0.71934, -0.527434, 0.452066, 0, 15, 0)
+transform = Transform3D(-0.694658, -0.546174, 0.468128, 0, 0.650774, 0.759271, -0.71934, 0.527434, -0.452066, 0, 15, 0)
 shadow_enabled = true
 
 [node name="Camera3D" type="Camera3D" parent="."]
@@ -42,3 +42,4 @@ metadata/blockdef_file = "res://resources/from_ylands/blockdef_2025_02.json"
 metadata/scene_file = "res://resources/from_ylands/scene_ref.json"
 metadata/box_draw_unsupported = true
 metadata/unsupported_transparency = 0.5
+metadata/mesh_combine_similar = false

--- a/csharp/scripts/ComboMesh.cs
+++ b/csharp/scripts/ComboMesh.cs
@@ -1,0 +1,170 @@
+using Godot;
+using Godot.Collections;
+
+namespace YlandsSceneLoader.scripts {
+
+public class ComboMeshItem
+{
+	public Array surface_data;
+	public StandardMaterial3D material;
+
+	public ComboMeshItem(Array surface_data, StandardMaterial3D material) {
+		this.surface_data = surface_data;
+		this.material = material;
+	}
+}
+
+public class ComboMesh
+{
+	private int surface_count;
+	private System.Collections.Generic.Dictionary<string, ComboMeshItem> cmesh;
+
+	public ComboMesh() {
+		this.cmesh = new System.Collections.Generic.Dictionary<string, ComboMeshItem>();
+	}
+
+	/// <param name="node"></param>
+	/// <returns><see cref="bool"/>; true if added successfully; false if full or invalid</returns>
+	public bool Append(Node3D node) {
+		int index;
+		MeshInstance3D mesh;
+
+		// Check if valid mesh containing node
+		mesh = node.GetChildOrNull<MeshInstance3D>(0);
+		if (mesh == null || mesh.Mesh == null) return false;
+
+		string color_uid = this.GetEntityColorUid(node);
+		if (color_uid.Length == 0) return false;
+
+		// Check if combined mesh is full
+		if (!this.cmesh.ContainsKey(color_uid) && this.surface_count == RenderingServer.MaxMeshSurfaces) {
+			return false;
+		}
+
+		// Apply node transfoorm to local verts and normals
+		Vector3 vert;
+		Vector3 norm;
+		Array surface_data = mesh.Mesh.SurfaceGetArrays(0);
+		Vector3[] local_verts = (Vector3[])surface_data[(int)Mesh.ArrayType.Vertex];
+		Vector3[] local_normals = (Vector3[])surface_data[(int)Mesh.ArrayType.Normal];
+		for (index = 0; index < local_verts.Length; index++) {
+			vert = local_verts[index];
+			norm = local_normals[index];
+			vert *= mesh.Scale;
+			vert = mesh.Quaternion * vert;
+			vert += mesh.Position;
+			vert *= node.Scale;
+			vert = node.Quaternion * vert;
+			vert += node.Position;
+			norm = node.Quaternion * mesh.Quaternion * norm;
+			local_verts[index] = vert;
+			local_normals[index] = norm;
+		}
+		surface_data[(int)Mesh.ArrayType.Vertex] = local_verts;
+		surface_data[(int)Mesh.ArrayType.Normal] = local_normals;
+
+		if (!this.cmesh.ContainsKey(color_uid)) {
+			// Add new surface data
+			this.cmesh[color_uid] = new ComboMeshItem(
+				surface_data,
+				YlandStandards.GetEntitySurfaceMaterial(node)
+			);
+		} else {
+			// Add to existing surface data
+			Array source;
+			Array target;
+			int vert_count_orig = 0;
+			for (index = 0; index < this.cmesh[color_uid].surface_data.Count; index++) {
+				if (index >= surface_data.Count) break;
+				source = (Array)surface_data[index];
+				target = (Array)this.cmesh[color_uid].surface_data[index];
+				if (source == null || source.Count == 0) continue;
+				if (index == (int)Mesh.ArrayType.Vertex) {
+					vert_count_orig = target.Count;
+				}
+				if (index == (int)Mesh.ArrayType.Index && vert_count_orig > 0) {
+					for (int mindex = 0; mindex < source.Count; mindex++) {
+						source[mindex] = (int)source[mindex] + vert_count_orig;
+					}
+				}
+				target.AddRange<Variant>(source);
+				this.cmesh[color_uid].surface_data[index] = target;
+			}
+
+			// Ensure modified generics are retyped properly so Godot C++ backend is a happy camper :)
+			// Note: Must correspond with ComboMesh.CommitToMesh.mesh_flags
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Vertex] =
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Vertex].As<Vector3[]>();
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Normal] =
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Normal].As<Vector3[]>();
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Tangent] =
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Tangent].As<float[]>();
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.TexUV] =
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.TexUV].As<Vector2[]>();
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Index] =
+			this.cmesh[color_uid].surface_data[(int)Mesh.ArrayType.Index].As<int[]>();
+		}
+
+		this.surface_count += 1;
+
+		return true;
+	}
+
+	public MeshInstance3D CommitToMesh(int id=0) {
+		if (this.surface_count == 0) return null;
+
+		// Create the actual mesh
+		ArrayMesh new_mesh = new ArrayMesh();
+		Mesh.ArrayFormat mesh_flags = Mesh.ArrayFormat.FormatVertex | Mesh.ArrayFormat.FormatNormal | Mesh.ArrayFormat.FormatTangent | Mesh.ArrayFormat.FormatTexUV | Mesh.ArrayFormat.FormatIndex;
+		Array data;
+		StandardMaterial3D mat;
+		int index = 0;
+		foreach (string key in this.cmesh.Keys) {
+			data = this.cmesh[key].surface_data;
+			mat = this.cmesh[key].material;
+			new_mesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, data, null, null, mesh_flags);
+			new_mesh.SurfaceSetMaterial(index, mat);
+			index += 1;
+		}
+
+		MeshInstance3D mesh_container = new MeshInstance3D();
+		mesh_container.Mesh = new_mesh;
+		mesh_container.Position = Vector3.Zero;
+		mesh_container.Quaternion = Quaternion.Identity;
+		if (id > -1) {
+			mesh_container.Name = $"[{id:d}] Combined Mesh";
+		} else {
+			mesh_container.Name = "Combined Mesh";
+		}
+
+		this.cmesh.Clear();
+		this.surface_count = 0;
+
+		return mesh_container;
+	}
+
+	private string GetEntityColorUid(Node3D entity) {
+		string color_uid = "";
+		StandardMaterial3D mat = YlandStandards.GetEntitySurfaceMaterial(entity);
+		if (mat == null) return "";
+
+		color_uid += mat.AlbedoColor.ToHtml();
+		if (mat.EmissionEnabled) {
+			color_uid += " e:" + mat.Emission.ToHtml();
+		}
+
+		return color_uid;
+	}
+
+	static public void ImmediateFreeNodeAndChildren(Node node) {
+		Node child;
+		for (int index = 0; index < node.GetChildCount(); index++) {
+			child = node.GetChild(index);
+			if (child == null || child.IsQueuedForDeletion()) continue;
+			ComboMesh.ImmediateFreeNodeAndChildren(child);
+		}
+		node.Free();
+	}
+}
+
+}

--- a/csharp/scripts/YlandsStandards.cs
+++ b/csharp/scripts/YlandsStandards.cs
@@ -1,0 +1,69 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace YlandsSceneLoader.scripts {
+
+public partial class YlandStandards
+{
+	public const float std_unit = 0.375f;
+	public const float std_half_unit = 0.1875f;
+	
+	static public Dictionary<string, PackedScene> shape_lookup = new Dictionary<string, PackedScene>();
+	static public Dictionary<string, PackedScene> type_lookup = new Dictionary<string, PackedScene>();
+	static public Dictionary<string, PackedScene> id_lookup = new Dictionary<string, PackedScene>();
+
+	static public void PreloadLookups() {
+		string base_dir = "res://scenes/packed/";
+
+		YlandStandards.shape_lookup["STANDARD"] = GD.Load<PackedScene>(base_dir + "ylands_block_std.tscn");
+		YlandStandards.shape_lookup["SLOPE"] = GD.Load<PackedScene>(base_dir + "ylands_block_slope.tscn");
+		YlandStandards.shape_lookup["CORNER"] = GD.Load<PackedScene>(base_dir + "ylands_block_corner.tscn");
+		YlandStandards.shape_lookup["SPIKE"] = GD.Load<PackedScene>(base_dir + "ylands_block_spike.tscn");
+
+		YlandStandards.type_lookup["MUSKET BALL"] = GD.Load<PackedScene>(base_dir + "ylands_type_musket_ball.tscn");
+
+		YlandStandards.id_lookup["3966"] = GD.Load<PackedScene>(base_dir + "ylands_block_glass_window_1x1x1_3966.tscn");
+		YlandStandards.id_lookup["2756"] = GD.Load<PackedScene>(base_dir + "ylands_block_glass_window_2x2x1_2756.tscn");
+		YlandStandards.id_lookup["5617"] = GD.Load<PackedScene>(base_dir + "ylands_block_glass_window_2x4x1_5617.tscn");
+		YlandStandards.id_lookup["5618"] = GD.Load<PackedScene>(base_dir + "ylands_block_glass_window_4x4x1_5618.tscn");
+		YlandStandards.id_lookup["3978"] = GD.Load<PackedScene>(base_dir + "ylands_ship_hull_wooden_large_3978.tscn");
+	}
+
+	static public void SetEntityColor(Node3D entity, List<float> color) {
+		if (color.Count < 3) return;
+		StandardMaterial3D mat = YlandStandards.GetEntitySurfaceMaterial(entity);
+		if (mat == null) return;
+
+		mat.AlbedoColor = new Color(
+			color[0],
+			color[1],
+			color[2],
+			mat.AlbedoColor.A
+		);
+		if (color.Count > 3 && color[3] > 0.001f) {
+			mat.EmissionEnabled = true;
+			mat.Emission = new Color(
+				color[0] * color[3],
+				color[1] * color[3],
+				color[2] * color[3]
+			);
+			mat.EmissionEnergyMultiplier = color[3] * 20f;
+			mat.RimEnabled = true;
+			mat.Rim = 1.0f;
+		} 
+	}
+
+	static public StandardMaterial3D GetEntitySurfaceMaterial(Node3D entity) {
+		StandardMaterial3D mat = null;
+
+		MeshInstance3D mesh = entity.GetChildOrNull<MeshInstance3D>(0);
+		if (mesh == null) return null;
+
+		mat = (StandardMaterial3D)mesh.GetSurfaceOverrideMaterial(0);
+		mat ??= (StandardMaterial3D)mesh.Mesh.SurfaceGetMaterial(0);
+
+		return mat;
+	}
+}
+
+}

--- a/native/scenes/loader_scene.tscn
+++ b/native/scenes/loader_scene.tscn
@@ -42,3 +42,4 @@ metadata/blockdef_file = "res://resources/from_ylands/blockdef_2025_02.json"
 metadata/scene_file = "res://resources/from_ylands/scene_ref.json"
 metadata/box_draw_unsupported = true
 metadata/unsupported_transparency = 0.5
+metadata/mesh_combine_similar = false

--- a/native/scripts/ComboMesh.gd
+++ b/native/scripts/ComboMesh.gd
@@ -65,12 +65,8 @@ func append(node: Node3D) -> bool:
 	
 	return true
 
-func commit_to_node(id: int = 0) -> MeshInstance3D:
+func commit_to_mesh(id: int = 0) -> MeshInstance3D:
 	if not cmesh: return null
-	#var node = Node3D.new()
-	#node.position = Vector3.ZERO
-	#node.quaternion = Quaternion.IDENTITY
-	#node.name = "[%d] Combined Mesh" % id
 	
 	# Create the actual combined mesh and add to node
 	var new_mesh = ArrayMesh.new()
@@ -94,8 +90,6 @@ func commit_to_node(id: int = 0) -> MeshInstance3D:
 	else:
 		mesh_container.name = "Combined Mesh"
 	
-	#var node = Node3D.new()
-	#node.add_child(mesh_container)
 	cmesh.clear()
 	
 	return mesh_container

--- a/native/scripts/ComboMesh.gd
+++ b/native/scripts/ComboMesh.gd
@@ -1,0 +1,124 @@
+class_name ComboMesh
+
+var cmesh: Dictionary
+
+func _init() -> void:
+	cmesh = {}
+
+func append(node: Node3D) -> bool:
+	'''
+	Return bool; true if added successfully; false if full or invalid
+	'''
+	var check_child: Node
+	var mesh: MeshInstance3D
+	
+	# Check if valid mesh containing node
+	check_child = node.get_child(0)
+	if not check_child or not is_instance_of(check_child, MeshInstance3D): return -1
+	mesh = check_child
+	if not mesh.mesh: return false
+	
+	var color_uid = _get_entity_color_uid(node)
+	if not color_uid: return false
+	
+	# Check if combined mesh is full
+	if not color_uid in cmesh and cmesh.size() == RenderingServer.MAX_MESH_SURFACES:
+		return false
+	
+	# Apply node transform to local verts and normals
+	var vert: Vector3
+	var norm: Vector3
+	var surface_data = mesh.mesh.surface_get_arrays(0)
+	var local_verts = surface_data[Mesh.ARRAY_VERTEX]
+	var local_normals = surface_data[Mesh.ARRAY_NORMAL]
+	for index in range(local_verts.size()):
+		vert = local_verts[index]
+		norm = local_normals[index]
+		vert *= mesh.scale
+		vert = mesh.quaternion * vert
+		vert += mesh.position
+		vert *= node.scale
+		vert = node.quaternion * vert
+		vert += node.position
+		norm = node.quaternion * mesh.quaternion * norm
+		local_verts[index] = vert
+		local_normals[index] = norm
+	
+	if color_uid not in cmesh:
+		# Create new surface
+		cmesh[color_uid] = [
+			surface_data,
+			YlandStandards.get_entity_surface_material(node)
+		]
+	else:
+		# Add to existing surface
+		var vert_count_orig = 0
+		for index in range(cmesh[color_uid][0].size()):
+			if index >= surface_data.size(): break
+			if not surface_data[index]: continue
+			if index == Mesh.ARRAY_VERTEX:
+				vert_count_orig = cmesh[color_uid][0][index].size()
+			if index == Mesh.ARRAY_INDEX and vert_count_orig:
+				for mindex in range(surface_data[index].size()):
+					surface_data[index][mindex] += vert_count_orig
+			cmesh[color_uid][0][index].append_array(surface_data[index])
+	
+	return true
+
+func commit_to_node(id: int = 0) -> MeshInstance3D:
+	if not cmesh: return null
+	#var node = Node3D.new()
+	#node.position = Vector3.ZERO
+	#node.quaternion = Quaternion.IDENTITY
+	#node.name = "[%d] Combined Mesh" % id
+	
+	# Create the actual combined mesh and add to node
+	var new_mesh = ArrayMesh.new()
+	var mesh_flags = Mesh.ARRAY_VERTEX | Mesh.ARRAY_NORMAL | Mesh.ARRAY_TANGENT | Mesh.ARRAY_FORMAT_TEX_UV | Mesh.ARRAY_INDEX
+	var data: Array
+	var mat: StandardMaterial3D
+	var index = 0
+	for key in cmesh:
+		data = cmesh[key][0]
+		mat = cmesh[key][1]
+		new_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, data, [], {}, mesh_flags)
+		new_mesh.surface_set_material(index, mat)
+		index += 1
+	
+	var mesh_container = MeshInstance3D.new()
+	mesh_container.mesh = new_mesh
+	mesh_container.position = Vector3.ZERO
+	mesh_container.quaternion = Quaternion.IDENTITY
+	if id:
+		mesh_container.name = "[%d] Combined Mesh" % id
+	else:
+		mesh_container.name = "Combined Mesh"
+	
+	#var node = Node3D.new()
+	#node.add_child(mesh_container)
+	cmesh.clear()
+	
+	return mesh_container
+
+func _get_entity_color_uid(entity: Node3D) -> String:
+	var color_uid = ""
+	var mat = YlandStandards.get_entity_surface_material(entity)
+	if not mat: return ""
+	
+	color_uid += mat.albedo_color.to_html()
+	if mat.emission_enabled:
+		color_uid += " e:" + mat.emission.to_html()
+	
+	return color_uid
+
+static func immidiate_free_node_and_children(node: Node) -> void:
+	var child: Node
+	for index in range(node.get_child_count()):
+		child = node.get_child(index)
+		if not child or child.is_queued_for_deletion(): continue
+		ComboMesh.immidiate_free_node_and_children(child)
+	# Handle material override free issue: https://github.com/godotengine/godot/issues/85817
+	if is_instance_of(node, MeshInstance3D):
+		for index in range(node.get_surface_override_material_count()):
+			node.set_surface_override_material(index, null)
+	node.free()

--- a/native/scripts/ComboMesh.gd
+++ b/native/scripts/ComboMesh.gd
@@ -47,13 +47,13 @@ func append(node: Node3D) -> bool:
 		local_normals[index] = norm
 	
 	if color_uid not in _cmesh:
-		# Create new surface
+		# Add new surface data
 		_cmesh[color_uid] = [
 			surface_data,
 			YlandStandards.get_entity_surface_material(node)
 		]
 	else:
-		# Add to existing surface
+		# Add to existing surface data
 		var vert_count_orig = 0
 		for index in range(_cmesh[color_uid][0].size()):
 			if index >= surface_data.size(): break
@@ -69,10 +69,10 @@ func append(node: Node3D) -> bool:
 	
 	return true
 
-func commit_to_mesh(id: int = 0) -> MeshInstance3D:
-	if not _cmesh: return null
+func commit_to_mesh(id: int = -1) -> MeshInstance3D:
+	if _surface_count == 0: return null
 	
-	# Create the actual combined mesh and add to node
+	# Create the actual mesh
 	var new_mesh = ArrayMesh.new()
 	var mesh_flags = Mesh.ARRAY_VERTEX | Mesh.ARRAY_NORMAL | Mesh.ARRAY_TANGENT | Mesh.ARRAY_FORMAT_TEX_UV | Mesh.ARRAY_INDEX
 	var data: Array
@@ -89,7 +89,7 @@ func commit_to_mesh(id: int = 0) -> MeshInstance3D:
 	mesh_container.mesh = new_mesh
 	mesh_container.position = Vector3.ZERO
 	mesh_container.quaternion = Quaternion.IDENTITY
-	if id:
+	if id > -1:
 		mesh_container.name = "[%d] Combined Mesh" % id
 	else:
 		mesh_container.name = "Combined Mesh"
@@ -110,12 +110,12 @@ func _get_entity_color_uid(entity: Node3D) -> String:
 	
 	return color_uid
 
-static func immidiate_free_node_and_children(node: Node) -> void:
+static func immediate_free_node_and_children(node: Node) -> void:
 	var child: Node
 	for index in range(node.get_child_count()):
 		child = node.get_child(index)
 		if not child or child.is_queued_for_deletion(): continue
-		ComboMesh.immidiate_free_node_and_children(child)
+		ComboMesh.immediate_free_node_and_children(child)
 	# Handle material override free issue: https://github.com/godotengine/godot/issues/85817
 	if is_instance_of(node, MeshInstance3D):
 		for index in range(node.get_surface_override_material_count()):

--- a/native/scripts/YlandStandards.gd
+++ b/native/scripts/YlandStandards.gd
@@ -22,3 +22,37 @@ static func preload_lookups() -> void:
 	YlandStandards.id_lookup['5617'] = load(base_dir + "ylands_block_glass_window_2x4x1_5617.tscn")
 	YlandStandards.id_lookup['5618'] = load(base_dir + "ylands_block_glass_window_4x4x1_5618.tscn")
 	YlandStandards.id_lookup['3978'] = load(base_dir + "ylands_ship_hull_wooden_large_3978.tscn")
+
+static func set_entity_color(entity: Node3D, color: Array) -> void:
+	if color.size() < 3: return
+	var mat = YlandStandards.get_entity_surface_material(entity)
+	if not mat: return
+	
+	mat.albedo_color = Color(
+		color[0],
+		color[1],
+		color[2],
+		mat.albedo_color.a
+	)
+	if color.size() > 3 and color[3] > 0.001:
+		mat.emission_enabled = true
+		mat.emission = Color(
+			color[0] * color[3],
+			color[1] * color[3],
+			color[2] * color[3]
+		)
+		mat.emission_energy_multiplier = color[3] * 20
+		mat.rim_enabled = true
+		mat.rim = 1
+
+static func get_entity_surface_material(entity: Node3D) -> StandardMaterial3D:
+	var mat: StandardMaterial3D = null
+	
+	var mesh = entity.get_child(0) as MeshInstance3D
+	if not mesh: return null
+	
+	mat = mesh.get_surface_override_material(0)
+	mat = mat if mat else mesh.mesh.surface_get_material(0)
+	if not mat: return null
+	
+	return mat

--- a/native/scripts/YlandStandards.gd
+++ b/native/scripts/YlandStandards.gd
@@ -53,6 +53,5 @@ static func get_entity_surface_material(entity: Node3D) -> StandardMaterial3D:
 	
 	mat = mesh.get_surface_override_material(0)
 	mat = mat if mat else mesh.mesh.surface_get_material(0)
-	if not mat: return null
 	
 	return mat

--- a/native/scripts/YlandsLoader.gd
+++ b/native/scripts/YlandsLoader.gd
@@ -35,8 +35,7 @@ func _process(_delta: float) -> void:
 
 func _build_scene(parent: Node3D, root: Dictionary) -> void:
 	var node: Node3D
-	var status: int
-	var combo_mesh = {}
+	var combo_mesh = ComboMesh.new()
 	var parent_inv_rotation = parent.quaternion.inverse()
 	
 	for key in root:
@@ -47,32 +46,30 @@ func _build_scene(parent: Node3D, root: Dictionary) -> void:
 		node.position = parent_inv_rotation * (node.position - parent.position)
 		node.quaternion = parent_inv_rotation * node.quaternion
 		
-		if combine_mesh:
-			status = _add_to_combo_mesh(combo_mesh, node)
-			if status == -1:
+		if not combine_mesh:
+			parent.add_child(node)
+		# Ignore the rest of this function (if reviewing as simple example - combo_mesh is an advanced feature)
+		else:
+			if root[key]['type'] == "group":
 				parent.add_child(node)
 				continue
-			elif status == 0:
-				parent.add_child(_combo_mesh_to_node(combo_mesh))
-				combo_mesh = {}
-				status = _add_to_combo_mesh(combo_mesh, node)
-				if status != 1:
-					assert(false, "Shouldn't be able to reach this; something very wrong happened")
-			_immidiate_free_node_and_children(node)
-		else:
-			parent.add_child(node)
+			if not combo_mesh.append(node):
+				parent.add_child(combo_mesh.commit_to_node(), true)
+				combo_mesh.append(node)
+			ComboMesh.immidiate_free_node_and_children(node)
 	
+	# Ignore this (if reviewing as simple example - combo_mesh is an advanced feature)
 	if combine_mesh:
-		parent.add_child(_combo_mesh_to_node(combo_mesh))
+		parent.add_child(combo_mesh.commit_to_node(), true)
+		cm_count += 1
 
 func _get_node_from_item(item: Dictionary) -> Node3D:
 	var node: Node3D = null
 	
 	if item['type'] == "entity":
 		node = _create_new_entity_from_ref(item['blockdef'])
-		if node:
-			if item.has('colors') and item['colors'].size() >= 1:
-				_set_entity_color(node, item['colors'][0])
+		if node and item.has('colors') and item['colors'].size() >= 1:
+			YlandStandards.set_entity_color(node, item['colors'][0])
 	elif item['type'] == "group":
 		node = Node3D.new()
 	
@@ -152,150 +149,8 @@ func _create_new_entity_from_ref(ref_key: String) -> Node3D:
 	
 	if node:
 		if block_ref.has('colors') and block_ref['colors'].size() >= 1:
-			_set_entity_color(node, block_ref['colors'][0])
+			YlandStandards.set_entity_color(node, block_ref['colors'][0])
 	else:
 		print("Unsupported Entity: %s" % block_ref)
 	
 	return node
-
-func _set_entity_color(entity: Node3D, color: Array) -> void:
-	if color.size() < 3: return
-	var mat = _get_entity_surface_material(entity)
-	if not mat: return
-	
-	mat.albedo_color = Color(
-		color[0],
-		color[1],
-		color[2],
-		mat.albedo_color.a
-	)
-	if color.size() > 3 and color[3] > 0.001:
-		mat.emission_enabled = true
-		mat.emission = Color(
-			color[0] * color[3],
-			color[1] * color[3],
-			color[2] * color[3]
-		)
-		mat.emission_energy_multiplier = color[3] * 20
-		mat.rim_enabled = true
-		mat.rim = 1
-
-func _get_entity_color_uid(entity: Node3D) -> String:
-	var color_uid = ""
-	var mat = _get_entity_surface_material(entity)
-	if not mat: return ""
-	
-	color_uid += mat.albedo_color.to_html()
-	if mat.emission_enabled:
-		color_uid += " e:" + mat.emission.to_html()
-	
-	return color_uid
-
-func _get_entity_surface_material(entity: Node3D) -> StandardMaterial3D:
-	var mat: StandardMaterial3D = null
-	
-	var mesh = entity.get_child(0) as MeshInstance3D
-	if not mesh: return null
-	
-	mat = mesh.get_surface_override_material(0)
-	mat = mat if mat else mesh.mesh.surface_get_material(0)
-	if not mat: return null
-	
-	return mat
-
-func _add_to_combo_mesh(combo: Dictionary, node: Node3D) -> int:
-	'''
-	Return status: <int> -1: invalid | 0: combo full | 1: success
-	'''
-	var check_child: Node
-	var mesh: MeshInstance3D
-	
-	# Check if valid mesh containing node
-	check_child = node.get_child(0)
-	if not check_child or not is_instance_of(check_child, MeshInstance3D): return -1
-	mesh = check_child
-	if not mesh.mesh: return -1
-	
-	var color_uid = _get_entity_color_uid(node)
-	if not color_uid: return -1
-	
-	# Check if combined mesh is full
-	if not color_uid in combo and combo.size() == RenderingServer.MAX_MESH_SURFACES:
-		return 0
-	
-	# Apply node transform to local verts and normals
-	var vert: Vector3
-	var norm: Vector3
-	var surface_data = mesh.mesh.surface_get_arrays(0)
-	var local_verts = surface_data[Mesh.ARRAY_VERTEX]
-	var local_normals = surface_data[Mesh.ARRAY_NORMAL]
-	for index in range(local_verts.size()):
-		vert = local_verts[index]
-		norm = local_normals[index]
-		vert *= mesh.scale
-		vert = mesh.quaternion * vert
-		vert += mesh.position
-		vert *= node.scale
-		vert = node.quaternion * vert
-		vert += node.position
-		norm = node.quaternion * mesh.quaternion * norm
-		local_verts[index] = vert
-		local_normals[index] = norm
-	
-	if color_uid not in combo:
-		# Create new surface
-		combo[color_uid] = [
-			surface_data,
-			_get_entity_surface_material(node)
-		]
-	else:
-		# Add to existing surface
-		var vert_count_orig = 0
-		for index in range(combo[color_uid][0].size()):
-			if index >= surface_data.size(): break
-			if not surface_data[index]: continue
-			if index == Mesh.ARRAY_VERTEX:
-				vert_count_orig = combo[color_uid][0][index].size()
-			if index == Mesh.ARRAY_INDEX and vert_count_orig:
-				for mindex in range(surface_data[index].size()):
-					surface_data[index][mindex] += vert_count_orig
-			combo[color_uid][0][index].append_array(surface_data[index])
-	
-	return 1
-
-func _combo_mesh_to_node(combo: Dictionary) -> Node3D:
-	if not combo: return
-	var node = Node3D.new()
-	node.position = Vector3.ZERO
-	node.quaternion = Quaternion.IDENTITY
-	node.name = "[%d] Combined Mesh" % cm_count
-	cm_count += 1
-	
-	# Create the actual combined mesh and add to node
-	var mesh_container = MeshInstance3D.new()
-	var new_mesh = ArrayMesh.new()
-	var mesh_flags = Mesh.ARRAY_VERTEX | Mesh.ARRAY_NORMAL | Mesh.ARRAY_TANGENT | Mesh.ARRAY_FORMAT_TEX_UV | Mesh.ARRAY_INDEX
-	var data: Array
-	var mat: StandardMaterial3D
-	var index = 0
-	for key in combo:
-		data = combo[key][0]
-		mat = combo[key][1]
-		new_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, data, [], {}, mesh_flags)
-		new_mesh.surface_set_material(index, mat)
-		index += 1
-	mesh_container.mesh = new_mesh
-	node.add_child(mesh_container)
-	return node
-
-func _immidiate_free_node_and_children(node: Node) -> void:
-	var child: Node
-	for index in range(node.get_child_count()):
-		child = node.get_child(index)
-		if not child or child.is_queued_for_deletion(): continue
-		_immidiate_free_node_and_children(child)
-	# Handle material override free issue: https://github.com/godotengine/godot/issues/85817
-	if is_instance_of(node, MeshInstance3D):
-		for index in range(node.get_surface_override_material_count()):
-			node.set_surface_override_material(index, null)
-	node.free()

--- a/native/scripts/YlandsLoader.gd
+++ b/native/scripts/YlandsLoader.gd
@@ -53,7 +53,7 @@ func _build_scene(parent: Node3D, root: Dictionary) -> void:
 				parent.add_child(node)
 				continue
 			elif status == 0:
-				_add_single_mesh_to_parent(parent, combo_mesh)
+				parent.add_child(_combo_mesh_to_node(combo_mesh))
 				combo_mesh = {}
 				status = _add_to_combo_mesh(combo_mesh, node)
 				if status != 1:
@@ -63,7 +63,7 @@ func _build_scene(parent: Node3D, root: Dictionary) -> void:
 			parent.add_child(node)
 	
 	if combine_mesh:
-		_add_single_mesh_to_parent(parent, combo_mesh)
+		parent.add_child(_combo_mesh_to_node(combo_mesh))
 
 func _get_node_from_item(item: Dictionary) -> Node3D:
 	var node: Node3D = null
@@ -263,7 +263,7 @@ func _add_to_combo_mesh(combo: Dictionary, node: Node3D) -> int:
 	
 	return 1
 
-func _add_single_mesh_to_parent(parent: Node3D, combo: Dictionary) -> void:
+func _combo_mesh_to_node(combo: Dictionary) -> Node3D:
 	if not combo: return
 	var node = Node3D.new()
 	node.position = Vector3.ZERO
@@ -286,7 +286,7 @@ func _add_single_mesh_to_parent(parent: Node3D, combo: Dictionary) -> void:
 		index += 1
 	mesh_container.mesh = new_mesh
 	node.add_child(mesh_container)
-	parent.add_child(node)
+	return node
 
 func _immidiate_free_node_and_children(node: Node) -> void:
 	var child: Node
@@ -299,20 +299,3 @@ func _immidiate_free_node_and_children(node: Node) -> void:
 		for index in range(node.get_surface_override_material_count()):
 			node.set_surface_override_material(index, null)
 	node.free()
-
-func create_mesh() -> ArrayMesh:
-	# RenderingServer.MAX_MESH_SURFACES
-	var test = ArrayMesh.new()
-	var vertices = PackedVector3Array()
-	vertices.push_back(Vector3(0, 1, 0))
-	vertices.push_back(Vector3(1, 0, 0))
-	vertices.push_back(Vector3(0, 0, 1))
-
-	# Initialize the ArrayMesh.
-	var arrays = []
-	arrays.resize(Mesh.ARRAY_MAX)
-	arrays[Mesh.ARRAY_VERTEX] = vertices
-
-	# Create the Mesh.
-	test.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
-	return test

--- a/native/scripts/YlandsLoader.gd
+++ b/native/scripts/YlandsLoader.gd
@@ -4,7 +4,6 @@ var load_scene: bool
 var combine_mesh: bool
 var unsupported_draw: bool
 var unsupported_transparency: float
-var cm_count: int
 var blocks: Dictionary
 var scene: Dictionary
 
@@ -25,7 +24,6 @@ func _ready() -> void:
 	YlandStandards.preload_lookups()
 	
 	load_scene = true
-	cm_count = 0
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
@@ -54,14 +52,13 @@ func _build_scene(parent: Node3D, root: Dictionary) -> void:
 				parent.add_child(node)
 				continue
 			if not combo_mesh.append(node):
-				parent.add_child(combo_mesh.commit_to_node(), true)
+				parent.add_child(combo_mesh.commit_to_mesh(), true)
 				combo_mesh.append(node)
 			ComboMesh.immidiate_free_node_and_children(node)
 	
 	# Ignore this (if reviewing as simple example - combo_mesh is an advanced feature)
 	if combine_mesh:
-		parent.add_child(combo_mesh.commit_to_node(), true)
-		cm_count += 1
+		parent.add_child(combo_mesh.commit_to_mesh(), true)
 
 func _get_node_from_item(item: Dictionary) -> Node3D:
 	var node: Node3D = null

--- a/native/scripts/YlandsLoader.gd
+++ b/native/scripts/YlandsLoader.gd
@@ -54,7 +54,7 @@ func _build_scene(parent: Node3D, root: Dictionary) -> void:
 			if not combo_mesh.append(node):
 				parent.add_child(combo_mesh.commit_to_mesh(), true)
 				combo_mesh.append(node)
-			ComboMesh.immidiate_free_node_and_children(node)
+			ComboMesh.immediate_free_node_and_children(node)
 	
 	# Ignore this (if reviewing as simple example - combo_mesh is an advanced feature)
 	if combine_mesh:


### PR DESCRIPTION
Option to combine mesh on load.
This will take all meshes within the same group and have the same material attributes, merged into a single mesh.
Load times are increased with this option enabled, but runtime performance is significantly improved.
The scene hierarchy is also improved with this and saving remote scenes is possible (including exporting as gltf).